### PR TITLE
#49973: Generate stable cache keys

### DIFF
--- a/lib/resterl.rb
+++ b/lib/resterl.rb
@@ -14,6 +14,7 @@ require 'resterl/caches/redis_cache'
 require 'resterl/caches/simple_cache'
 require 'resterl/caches/rails_memcached_cache'
 require 'resterl/caches/key_prefix_decorator'
+require 'resterl/caches/cache_key_generator'
 require 'resterl/caches/nil_cache'
 
 require 'resterl/client'

--- a/lib/resterl/caches/cache_key_generator.rb
+++ b/lib/resterl/caches/cache_key_generator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Resterl
+  module Caches
+    class CacheKeyGenerator
+      def self.generate(url, params, headers)
+        normalized = [url, params, headers].map do |part|
+          part.is_a?(Hash) ? part.sort : part
+        end.each_with_object(+'') { |e, acc| acc << e.inspect }
+
+        Digest::SHA1.hexdigest(normalized)
+      end
+    end
+  end
+end

--- a/lib/resterl/client.rb
+++ b/lib/resterl/client.rb
@@ -97,8 +97,8 @@ module Resterl
       end
     end
 
-    def data_to_cache_key *args
-      args.hash
+    def data_to_cache_key url, params, headers
+      Caches::CacheKeyGenerator.generate(url, params, headers)
     end
 
     def get_response(request, old_response)

--- a/lib/resterl/version.rb
+++ b/lib/resterl/version.rb
@@ -1,3 +1,3 @@
 module Resterl
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end

--- a/spec/lib/resterl/caches/cache_key_generator_spec.rb
+++ b/spec/lib/resterl/caches/cache_key_generator_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe Resterl::Caches::CacheKeyGenerator do
+  it 'generates a stable digest for the same url' do
+    a = described_class.generate('http://example.com', {}, {})
+    b = described_class.generate('http://example.com', {}, {})
+
+    expect(a).to eq b
+  end
+
+  it 'generates a stable digest with the same parameters' do
+    a = described_class
+      .generate('http://example.com', { 'foo' => 'bar' }, {})
+    b = described_class
+      .generate('http://example.com', { 'foo' => 'bar' }, {})
+
+    expect(a).to eq b
+  end
+
+  it 'generates a stable digest with the same headers' do
+    a = described_class
+      .generate('http://example.com', {}, 'x-test' => '0.5')
+    b = described_class
+      .generate('http://example.com', {}, 'x-test' => '0.5')
+
+    expect(a).to eq b
+  end
+
+  it 'generates a stable digest with same url, params and headers' do
+    a = described_class
+      .generate('http://example.com', { 'xy' => 'xxx' }, 'x-test' => '0.5')
+    b = described_class
+      .generate('http://example.com', { 'xy' => 'xxx' }, 'x-test' => '0.5')
+
+    expect(a).to eq b
+  end
+
+  it 'generates different digest for different urls' do
+    a = described_class.generate('http://example.net', {}, {})
+    b = described_class.generate('http://example.com', {}, {})
+
+    expect(a).not_to eq b
+  end
+
+  it 'generates different digest with different parameters' do
+    a = described_class.generate('http://example.com', { 'blib' => 'blub' }, {})
+    b = described_class.generate('http://example.com', { 'blib' => 'oopf' }, {})
+    c = described_class.generate('http://example.com', { 'oopf' => 'blip' }, {})
+
+    expect([a, b, c].uniq.length).to eq 3
+  end
+
+  it 'generates different digest with different headers' do
+    a = described_class
+      .generate('http://example.com', {}, 'accept' => 'json')
+    b = described_class
+      .generate('http://example.com', {}, 'accept' => '*/*')
+
+    expect(a).not_to eq b
+  end
+
+  it 'generates the same digest with url parameters and headers ' \
+    'in diffrent order' do
+    a = described_class.generate(
+      'http://example.com',
+      { 'a' => 'aaa', 'b' => 'bbb' },
+      'x-aaa' => 'aaa', 'x-bbb' => 'bbb'
+    )
+    b = described_class .generate(
+      'http://example.com',
+      { 'b' => 'bbb', 'a' => 'aaa' },
+      'x-bbb' => 'bbb', 'x-aaa' => 'aaa'
+    )
+
+    expect(a).to eq b
+  end
+end


### PR DESCRIPTION
Object#hash is not process safe and should not but be used for cache key
generation.